### PR TITLE
Actually build on Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,20 @@ matrix:
       env: CMAKEFLAGS="-DWITH_BOOST=ON -DHAS_MEMRCHR=OFF" CXX=clang++
     - compiler: gcc
       os: linux
+      dist: precise
+      sudo: false
+      addons:
+        apt:
+          sources:
+            - george-edison55-precise-backports
+          packages:
+            - cmake
+            - cmake-data
+            - libboost-system-dev
+            - libboost-filesystem-dev
+      env: CMAKEFLAGS="-DWITH_BOOST=ON" CXX=g++-4.6
+    - compiler: gcc
+      os: linux
       addons:
         apt:
           sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,14 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES GNU)
-  set(COMPILE_FLAGS -Wall -Wextra -Wpedantic)
+  include(CheckCXXCompilerFlag)
+
+  set(COMPILE_FLAGS -Wall -Wextra)
+
+  check_cxx_compiler_flag("-Wpedantic" PEDANTIC_SUPPORTED)
+  if(PEDANTIC_SUPPORTED)
+    list(APPEND COMPILE_FLAGS -Wpedantic)
+  endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(COMPILE_FLAGS /W4)
   # boost gets compiled as static libs on Windows

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ static bool CheckVersionFile() {
 std::string targetFrom(const std::string &arg) {
     std::string target = arg;
     if (!target.empty() && target.back() == '/') {
-        target.pop_back();
+        target.erase(target.end() - 1);
     }
     std::replace(target.begin(), target.end(), '.', '/');
     return "./" + target;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,13 @@
+include(WriteCompilerDetectionHeader)
+
+write_compiler_detection_header(
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/compiler_feature_detection.h"
+  PREFIX OPTIONAL_FEATURE
+  COMPILERS GNU Clang AppleClang MSVC
+  FEATURES
+    cxx_override
+)
+
 add_executable(unittests
   AnalysisCircularDependencies.cpp
   test.cpp
@@ -5,6 +15,10 @@ add_executable(unittests
 target_link_libraries(unittests
   PRIVATE
     cpp_dependencies_coverage
+)
+target_include_directories(unittests
+  PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set_property(TARGET unittests APPEND PROPERTY LINK_FLAGS --coverage)

--- a/test/test.h
+++ b/test/test.h
@@ -2,6 +2,7 @@
 #define TEST_H
 
 #include <stdexcept>
+#include "compiler_feature_detection.h"
 
 class Test {
 public:
@@ -18,7 +19,7 @@ private:
   static Test* firstTest;
 };
 
-#define TEST(x) static struct Test##x : public Test { Test##x() : Test(#x) {} void Run() override; } __inst_##x; void Test##x::Run()
+#define TEST(x) static struct Test##x : public Test { Test##x() : Test(#x) {} void Run() OPTIONAL_FEATURE_OVERRIDE; } __inst_##x; void Test##x::Run()
 #define ASSERT(x) do { auto v = (x); if (!v) { throw std::runtime_error("Assertion failed: " #x); } } while(0)
 
 #endif


### PR DESCRIPTION
Given that it's described as tested and supported on Ubuntu Precise (12.04) in the README this PR adds testing for that platform on Travis and subsequently fixes the reasons why it doesn't build there.